### PR TITLE
Fixed breaking changes from saction 0.4, and removed deprecated calls to sanction.client

### DIFF
--- a/django_sanction/backends.py
+++ b/django_sanction/backends.py
@@ -3,7 +3,7 @@
 """
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from sanction.client import Client as SanctionClient
+from sanction import Client as SanctionClient
 
 class AuthenticationBackend(object):
     """ Authentication backend for ``django_sanction``.
@@ -36,10 +36,10 @@ class AuthenticationBackend(object):
             resource_endpoint=provider['resource_endpoint'],
             auth_endpoint=provider['auth_endpoint'],
             client_id=provider['client_id'],
-            client_secret=provider['client_secret'],
-            redirect_uri=provider['redirect_uri'])
+            client_secret=provider['client_secret'])
 
-        c.request_token(code=code, parser=provider.get('parser', None))
+        c.request_token(code=code, parser=provider.get('parser', None),
+                        redirect_uri=provider['redirect_uri'])
 
         return model.fetch_user(provider_key, c)
 

--- a/django_sanction/views.py
+++ b/django_sanction/views.py
@@ -17,7 +17,7 @@ from django.utils.crypto import constant_time_compare
 from django.middleware import csrf
 from django.middleware.csrf import CsrfViewMiddleware
 
-from sanction.client import Client as SanctionClient
+from sanction import Client as SanctionClient
 
 def login(request, provider):
     """ Log in the current user following the OAuth 2.0 server flow
@@ -50,10 +50,14 @@ def login(request, provider):
 def _redirect(request, provider):
     p = settings.SANCTION_PROVIDERS[provider]
     c = SanctionClient(auth_endpoint=p['auth_endpoint'],
-        client_id=p['client_id'], redirect_uri=p['redirect_uri'])
+        client_id=p['client_id'], token_endpoint=p['token_endpoint'],
+        client_secret=p['client_secret'], 
+        resource_endpoint=p['resource_endpoint'])
 
     kwargs = p.get('auth_params', {})
-    response = redirect(c.auth_uri(p['scope'] if 'scope' in p else None, **kwargs))
+    response = redirect(c.auth_uri(redirect_uri = p['redirect_uri'],
+                                   scope = p['scope'] if 'scope' in p else None, 
+                                   **kwargs))
 
     # inject the state query param
     if getattr(settings, 'SANCTION_USE_CSRF', True):


### PR DESCRIPTION
Sanction 0.4 introduced some breaking changes. If downloading sanction using `easy_install`, sanction 0.4 is selected as the version to install. This broke django-sanction and resulted in OAuth2 simply not working.

This change fixes the calls to `sanction.Client.request_token` and `sanction.Client.auth_uri` and `sanction.Client.__init__`. 

Additionally, the `Client` class is imported directly from the `sanction` module, to avoid deprecation warnings.
